### PR TITLE
Plugin add fails alternately

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function(plugins) {
         cb();
     }, function(cb) {
         var promises = plugins.map(add);
-        
+
         Q.all(promises)
             .then(function() {
                 // Call the callback if all the plugins are added correctly
@@ -47,15 +47,15 @@ module.exports = function(plugins) {
 /**
  * Returns a promise that will add the plugin to the current working
  * directory cordova project.
- * 
+ *
  * @param {String} plugin   The name of the plugin that should be added.
  */
 function add(plugin) {
     return Q.fcall(function() {
         // Print which plugin will be added
         gutil.log('\tadd ' + plugin);
-        
+
         // Add the plugin
-        return shell.exec('cordova plugin add '+plugin);
+        return shell.exec('cordova plugin add '+plugin, {silent: true});
     });
 }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ var path = require('path'),
     through = require('through2'),
     gutil = require('gulp-util'),
     cordova = require('cordova-lib').cordova.raw,
-    Q = require('q');
+    Q = require('q'),
+    shell = require('shelljs');
 
 // export the module
 module.exports = function(plugins) {
@@ -55,6 +56,6 @@ function add(plugin) {
         gutil.log('\tadd ' + plugin);
         
         // Add the plugin
-        return cordova.plugin('add', plugin);
+        return shell.exec('cordova plugin add '+plugin);
     });
 }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@
 var path = require('path'),
     through = require('through2'),
     gutil = require('gulp-util'),
-    cordova = require('cordova-lib').cordova.raw,
     Q = require('q'),
     shell = require('shelljs');
 

--- a/package.json
+++ b/package.json
@@ -27,12 +27,9 @@
   },
   "homepage": "https://github.com/SamVerschueren/gulp-cordova-plugin",
   "dependencies": {
-    "cordova-lib": "^5.0.0",
     "gulp-util": "^3.0.4",
     "q": "^1.4.1",
+    "shelljs": "^0.5.1",
     "through2": "^0.6.5"
-  },
-  "devDependencies": {
-    "shelljs": "^0.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "gulp-util": "^3.0.4",
     "q": "^1.4.1",
     "through2": "^0.6.5"
+  },
+  "devDependencies": {
+    "shelljs": "^0.5.1"
   }
 }


### PR DESCRIPTION
Here is my gulp task:

```
var gulp = require('gulp'),
    plugin = require('gulp-cordova-plugin'),
    plugins = require('../package.json').cordovaPlugins,
    del = require('del'),
    shell = require('shelljs');

gulp.task('plugins:empty', function () {
  return shell.rm('-r', 'plugins');
});

gulp.task('plugins', ['plugins:empty'], function() {

return gulp.src('plugins')
      .pipe(plugin(plugins));
});
```

For some reason, when I run this task, it fails. Then when I run again it succeeds. Then when I run again it fails the second time. When I run again, it succeeds the second time.
