### PR TITLE
:arrow_up: cordova-lib@6.0.0 - fixes #18

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "index.js"
   ],
   "dependencies": {
-    "cordova-lib": "^5.4.1",
+    "cordova-lib": "^6.0.0",
     "gulp-util": "^3.0.4",
     "lodash": "^3.10.1",
     "pinkie-promise": "^2.0.0",


### PR DESCRIPTION
Bumping up the version has fixed my issue. Tested multiple time with success ! 
But be careful with plugin names ! The cordova team has moved their core plugins to npm and with cordova 6.0.0 they've removed the support of their old [CPR](http://cordova.apache.org/plugins/). 
see [this post](https://cordova.apache.org/announcements/2015/04/21/plugins-release-and-move-to-npm.html) to have more informations about the changes.
